### PR TITLE
Scope for displaying latest rewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 History for Surveyor
 ====================
 
+1.6.1
+-----
+
+### Features
+
+* Added scope for getting only latest version of a survey
+
+
+1.6.0
+-----
+
+### Fixes
+
+* Upgraded for Rails 5 (by Yuriy)
+
 1.5.0
 -----
 

--- a/lib/surveyor/models/survey_methods.rb
+++ b/lib/surveyor/models/survey_methods.rb
@@ -22,6 +22,9 @@ module Surveyor
         # Derived attributes
         before_save :generate_access_code
         before_save :increment_version
+
+        # Scopes
+        scope :latest_versions, -> { order('access_code asc, survey_version desc').select('distinct on ("access_code") *') }
       end
 
       module ClassMethods

--- a/lib/surveyor/version.rb
+++ b/lib/surveyor/version.rb
@@ -1,3 +1,3 @@
 module Surveyor
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end


### PR DESCRIPTION
Added scope for displaying only the latest versions of surveys to fix bug on frontend where multiple versions of a single survey were being returned.

https://blueboard.atlassian.net/browse/HELP-201